### PR TITLE
Backport geth security guards through v1.17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: go build ./...
         run: go build ./...
       - name: go vet (fork-touched packages)
-        run: go vet ./core/... ./rpc/... ./internal/ethapi/... ./crypto/...
+        run: go vet ./core/... ./rpc/... ./internal/ethapi/... ./crypto/... ./eth/protocols/snap
 
   test:
     name: unit tests (fork packages)
@@ -64,6 +64,8 @@ jobs:
       - name: go test (p2p security regression — targeted; full ./p2p has fork-inherited flaky tests)
         run: |
           go test ./p2p -run 'TestPeerPing|TestPeerPingFlood|TestPeerDisconnect'
+      - name: go test (snap response memory bounds)
+        run: go test ./eth/protocols/snap -run TestDecodeResponseListLimits
 
   race:
     name: race detector (concurrency-sensitive packages)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           go test ./p2p -run 'TestPeerPing|TestPeerPingFlood|TestPeerDisconnect'
       - name: go test (snap response memory bounds)
-        run: go test ./eth/protocols/snap -run TestDecodeResponseListLimits
+        run: go test ./eth/protocols/snap -run 'TestDecodeResponseListLimits|TestDecodeTrieNodePathsLimits'
 
   race:
     name: race detector (concurrency-sensitive packages)

--- a/SECURITY-TRIAGE.md
+++ b/SECURITY-TRIAGE.md
@@ -1,188 +1,42 @@
-# go-vinu — Post-1.10.8 Upstream Security Triage
+# go-vinu upstream security triage through geth v1.17.0
 
-Scope: published `ethereum/go-ethereum` security advisories with a fixed version
-**≥ v1.10.9**, triaged against this fork's actual code. Per the upstream-tracking
-policy ([FORK.md](./FORK.md) §3) the approach is **cherry-pick, never rebase**.
+`go-vinu` is based on geth v1.10.8 through Fantom's `develop-1.10.8` line.
+It intentionally cherry-picks applicable security fixes instead of rebasing,
+because a full geth rebase would mix consensus and EVM changes into VinuChain.
 
-Base: geth **v1.10.8** via Fantom's `develop-1.10.8` (merge-base `39f2942b`,
-2023-07-28). Note that Fantom's 1.10.8 line already absorbed some upstream
-backports, so a CVE "fixed after 1.10.8 upstream" is not automatically present
-here — each is checked against the code.
+VinuChain's runtime wiring was checked directly: it runs the devp2p server and
+registers its custom `opera` protocol plus the fork's `fsnap` protocol. It does
+not register geth's `eth` protocol. The dispositions below therefore assume
+devp2p and snap peer input is reachable.
 
-Method: for each CVE, locate the vulnerable code path; verify whether it is
-present and reachable in this fork; assign a verdict.
+| CVE | Upstream fix | Fork disposition |
+|---|---:|---|
+| CVE-2021-41173 | v1.10.9 | Not applicable: the inherited snap handler already has lookup, byte, and time bounds. |
+| CVE-2022-29177 | v1.10.17 | Applied: `DiscReason` is one byte and disconnect messages decode into a one-field list, matching geth PR #24507. |
+| CVE-2023-40591 | v1.12.1 | Applied: inbound pings use the single bounded `pingLoop`; `TestPeerPingFlood` covers it. |
+| CVE-2024-32972 | v1.13.15 | Not applicable: the vulnerable `GetHeadersFrom(num+count-1, count-1)` optimization does not exist; the inherited loop returns immediately for `Amount == 0`. The geth `eth` protocol is also not registered by VinuChain. |
+| CVE-2026-22862 | v1.16.8 | Applied: ECIES rejects ciphertext shorter than the public key, MAC, and AES block before slicing the IV; `TestDecryptRejectsShortCiphertext` covers it. |
+| CVE-2026-22868 | v1.16.8 | Not applicable: this fork has no blob transaction implementation or KZG verifier, rejects type `0x03` in both full and light transaction pools, and VinuChain does not use geth's transaction fetcher. |
+| CVE-2026-26313 | v1.17.0 | Applied to the reachable snap protocol: response lists remain raw until their encoded byte and item counts are bounded; `TestDecodeResponseListLimits` covers both limits. The unregistered geth `eth` handlers need no backport. |
+| CVE-2026-26314 | v1.16.9 | Applied in `e67de77a2`: `BitCurve.IsOnCurve` rejects nil, negative, and non-canonical coordinates; its regression test covers coordinates at and above the field prime. |
+| CVE-2026-26315 | v1.16.9 | Applied in `407a9c5ca`: ECIES validates peer coordinates before ECDH; off-curve and nil-coordinate regression tests cover it. |
 
----
+The effective fork version and the left-hand `github.com/ethereum/go-ethereum`
+requirement serve different tools. Go builds use the explicit `replace` to
+`github.com/VinuChain/go-vinu`; the left-hand version records the audited
+upstream advisory floor so Dependabot does not report fixes already present or
+proved inapplicable in the fork.
 
-## Threat-model gate (the load-bearing open question)
+These patches affect unauthenticated network parsing only. They do not change
+the EVM, state transition, receipt encoding, chain rules, activation heights,
+or protocol capability names.
 
-Every p2p/discovery CVE below is **conditional on the VinuChain node actually
-running this repo's devp2p server / discovery**. This is an Opera/Lachesis-style
-consumer that uses a custom wire protocol and consumes go-vinu primarily as an
-**EVM/state/types/RPC library**. Two possibilities:
+The separate `FeeRefundActive` audit concern was checked in the consumer. The
+node initializes it from stored rules and changes it in the serialized epoch
+seal path where Podgorica becomes effective. Pre-activation receipts have nil
+refunds, whose encoding is identical in either flag state. VinuChain's runtime
+activation and receipt-root tests pin that transition.
 
-- **If the node does NOT run `p2p.Server` / discv4 / discv5 / the eth & snap
-  protocol handlers**, then C1–C4 are all *not reachable* regardless of the
-  code, and only the RPC-surface items matter.
-- **If the node DOES run the devp2p server** (typical for full nodes even with
-  custom protocols), the reachable items below apply.
-
-This cannot be determined from this repo. **Owner action:** confirm the node's
-wiring. The cherry-pick applied below (C3) is safe and low-cost either way; the
-rest of the dispositions assume the worst case (devp2p server is running) so
-that "not applicable" verdicts rest on code facts, not on the assumption that
-the server is off.
-
----
-
-## Disposition table
-
-| ID | CVE | Fixed in | Class | Reachable here? | Verdict |
-|----|-----|----------|-------|-----------------|---------|
-| C1 | CVE-2021-41173 | v1.10.9 | snap/1 `GetTrieNodes` unbounded serve (DoS) | No — fix already in base | **Not applicable** |
-| C2 | CVE-2022-29177 | v1.10.17 | discv5 crafted packet crash under high-verbosity logging | Conditional (discv5 + TRACE/DEBUG logging) | **Needs decision** |
-| C3 | CVE-2023-40591 | v1.12.1 | devp2p ping handler spawns unbounded goroutines (DoS) | Yes (if devp2p server runs) | **Applied (cherry-pick #27887)** |
-| C4 | CVE-2024-32972 | v1.13.15 | eth `GetBlockHeadersRequest count=0` underflow (DoS) | No — vulnerable function not present | **Not applicable** |
-
----
-
-## C1 — CVE-2021-41173 (snap/1 GetTrieNodes) — NOT APPLICABLE
-
-**Vulnerability:** prior to v1.10.9, the snap protocol `GetTrieNodes` handler
-could be made to serve an unbounded number of trie nodes / spend unbounded time,
-crashing or stalling the node.
-
-**Check (code fact):** `eth/protocols/snap/handler.go` already enforces
-`maxTrieNodeLookups = 1024`, `maxTrieNodeTimeSpent = 5*time.Second`, and a
-per-iteration `bytes > req.Bytes || loads > maxTrieNodeLookups ||
-time.Since(start) > maxTrieNodeTimeSpent` break (handler.go:500, 506). These
-exact bounds are **already present in the 1.10.8 merge-base**
-(`git show 39f2942b:eth/protocols/snap/handler.go` shows them at the same lines).
-Fantom's 1.10.8 line was cut after this fix was backported upstream.
-
-**Verdict:** Not applicable — the fix is already in the base. No action.
-
----
-
-## C2 — CVE-2022-29177 (discv5 crafted-packet crash) — NEEDS DECISION
-
-**Vulnerability:** prior to v1.10.17, a node **configured for high-verbosity
-logging** (TRACE/DEBUG) could be crashed by a specially crafted discv5 p2p
-message. Workaround per the upstream advisory: run at the default `INFO`
-verbosity, which makes the node not vulnerable.
-
-**Check (code fact):** discv5 is present and reachable
-(`p2p/discover/v5wire/`, `p2p/discover/v5_udp.go`); `handlePacket`
-(v5_udp.go:657) logs decoded packet names at `Trace`/`Debug`. The crash path is
-in the verbose logging of malformed packets.
-
-**Why not auto-applied:** (a) severity is Low and the trigger requires a
-**non-default** logging configuration; (b) the precise upstream fix could not be
-pinned to an exact, cleanly-cherry-pickable diff against this fork's v5wire code
-during triage, so applying it blind would violate the "only clean, verified
-cherry-picks" rule. Applying an unverified packet-parsing patch to consensus-
-adjacent networking code is higher risk than the bug it would fix.
-
-**Owner action / decision needed:**
-1. Confirm production log verbosity. If the node runs at `INFO` (default), the
-   bug is **not triggerable** and this can be closed as accepted.
-2. If high-verbosity logging is used (or discv5 is exposed), pin the upstream
-   v1.10.17 v5wire fix commit and cherry-pick it with a malformed-packet
-   regression test.
-
-**Verdict:** Needs decision (conditional, mitigated by default config).
-
----
-
-## C3 — CVE-2023-40591 (ping goroutine flood) — APPLIED
-
-**Vulnerability:** the devp2p base-protocol ping handler responded to each
-inbound `pingMsg` by spawning a fresh goroutine (`go SendItems(p.rw, pongMsg)`).
-An attacker flooding a peer connection with pings could create an unbounded
-number of goroutines, exhausting memory (High, fixed upstream v1.12.1, PR
-ethereum/go-ethereum#27887).
-
-**Check (code fact):** the exact vulnerable line was present at
-`p2p/peer.go:325`:
-
-```go
-case msg.Code == pingMsg:
-    msg.Discard()
-    go SendItems(p.rw, pongMsg)   // <-- unbounded goroutine per ping
-```
-
-reachable from `Peer.handle` whenever this repo's `p2p.Server` runs.
-
-**Fix applied (cherry-pick of #27887):** added a buffered `pingRecv chan
-struct{}` (cap 16) to `Peer`; the ping handler now signals the existing single
-`pingLoop` goroutine instead of spawning one per ping; `pingLoop` sends the pong
-synchronously. This bounds the work a ping flood can induce to the existing,
-fixed set of per-peer goroutines.
-
-Files: `p2p/peer.go` (struct field, constructor init, ping handler, pingLoop
-case). Regression test: `p2p/peer_test.go::TestPeerPingFlood` (sends 64 pings,
-asserts 64 pongs; passes under `-race`).
-
-**Verdict:** Applied. `go build ./p2p/...`, `go vet ./p2p/`, and the peer/ping
-tests (`TestPeerPing`, `TestPeerPingFlood`, `TestPeerDisconnect*`) are green,
-including under `-race`.
-
-> Note: the p2p package has two **pre-existing, fork-inherited** test failures
-> (`TestServerSetupConn`, `TestServerPeerLimits`) that fail identically on the
-> unmodified base and are unrelated to this change. They are the reason the p2p
-> package is not in the CI test allow-list; they are recorded here as an owner
-> follow-up, not introduced by this work.
-
----
-
-## C4 — CVE-2024-32972 (GetBlockHeadersRequest count=0 underflow) — NOT APPLICABLE
-
-**Vulnerability:** prior to v1.13.15, the eth protocol header server used an
-optimized reverse-batch read `chain.GetHeadersFrom(num+count-1, count-1)`. A
-`GetBlockHeadersRequest` with `count == 0` made `count-1` underflow to
-`UINT64_MAX`, requesting all headers back to genesis and exhausting memory
-(High, fixed PR ethereum/go-ethereum#29534).
-
-**Check (code fact):** the vulnerable `GetHeadersFrom` optimization **does not
-exist** in this fork. Header serving uses the older 1.10.8 bounded loop
-`answerGetBlockHeadersQuery` (`eth/protocols/eth/handlers.go:52`), which iterates
-under `len(headers) < int(query.Amount)`, `bytes < softResponseLimit`,
-`len(headers) < maxHeadersServe`, and `lookups < 2*maxHeadersServe` guards. With
-`query.Amount == 0` the loop body never executes (no underflow). The reverse/
-skip arithmetic also has explicit overflow guards (handlers.go:93, 105).
-
-**Verdict:** Not applicable — the vulnerable function was never introduced into
-this base; the inherited loop is bounded.
-
----
-
-## FeeRefundActive consensus coupling (audit H1) — cross-reference
-
-Not an upstream CVE, but the highest consensus hazard. The process-global
-`FeeRefundActive atomic.Bool` (`core/types/receipt.go`) gates receipt-root
-encoding. Characterization tests in
-`core/types/fee_refund_epoch_test.go` prove that under a **concurrent flag
-flip**, `DeriveSha(Receipts)` can yield a receipt root matching neither epoch
-(per-index `EncodeIndex` reads the live flag). The flag access is race-free; the
-hazard is *logical epoch incorrectness*, not a data race.
-
-**Safe operating contract (must be honored by the consumer node):**
-`FeeRefundActive` MUST be set exactly once, before any block import / replay /
-RPC receipt derivation begins, and MUST NOT be flipped while the process is live.
-If the consumer instead flips it at the Podgorica block boundary mid-process,
-historical receipt re-encodes (sync, re-org, replay, RPC) become
-non-deterministic. **Owner action:** confirm the consumer sets the flag at
-process start (config-driven), not at the fork block; consider a one-way
-startup-only setter + assertion in both repos.
-
----
-
-## Owner action summary
-
-1. **Confirm devp2p wiring** — does the node run `p2p.Server` / discv4 / discv5 /
-   eth & snap handlers? This gates C2 and the reachability of C3.
-2. **C2** — confirm production log verbosity; if not `INFO`, pin & cherry-pick
-   the v1.10.17 discv5 fix with a regression test.
-3. **FeeRefundActive** — confirm set-once-at-startup contract in the consumer.
-4. **p2p pre-existing test failures** (`TestServerSetupConn`,
-   `TestServerPeerLimits`) — triage separately; inherited from the base.
+Two full-package p2p tests (`TestServerSetupConn` and `TestServerPeerLimits`)
+remain inherited timing/order flakes. CI runs the deterministic peer security
+tests directly; the VinuChain repository remains the full integration gate.

--- a/SECURITY-TRIAGE.md
+++ b/SECURITY-TRIAGE.md
@@ -21,11 +21,12 @@ devp2p and snap peer input is reachable.
 | CVE-2026-26314 | v1.16.9 | Applied on the supported Linux/CGO path: `BitCurve.IsOnCurve` rejects non-canonical coordinates and the C scalar multiplier checks field parsing; focused tests cover coordinates at the field prime. |
 | CVE-2026-26315 | v1.16.9 | Applied in `407a9c5ca`: ECIES validates peer coordinates before ECDH; off-curve and nil-coordinate regression tests cover it. |
 
-The effective fork version and the left-hand `github.com/ethereum/go-ethereum`
-requirement serve different tools. Go builds use the explicit `replace` to
-`github.com/VinuChain/go-vinu`; the left-hand version records the audited
-upstream advisory floor so Dependabot does not report fixes already present or
-proved inapplicable in the fork.
+In the consumer module `VinuChain/VinuChain`, the effective fork version and
+the left-hand `github.com/ethereum/go-ethereum` requirement serve different
+tools: its `go.mod` uses an explicit `replace` to `github.com/VinuChain/go-vinu`,
+while the left-hand version records the audited upstream advisory floor for
+Dependabot. This repository itself retains geth's module path and has no such
+replacement.
 
 These patches affect unauthenticated network parsing only. They do not change
 the EVM, state transition, receipt encoding, chain rules, activation heights,
@@ -35,11 +36,14 @@ Release binaries require Linux/CGO. The inherited non-CGO signature backend
 does not compile against the current btcec dependency and is not a supported
 VinuChain build target; no advisory disposition relies on it.
 
-The separate `FeeRefundActive` audit concern was checked in the consumer. The
-node initializes it from stored rules and changes it in the serialized epoch
-seal path where Podgorica becomes effective. Pre-activation receipts have nil
-refunds, whose encoding is identical in either flag state. VinuChain's runtime
-activation and receipt-root tests pin that transition.
+The generic `FeeRefundActive` torn-root interleaving remains real and covered by
+a stress test. It is not reachable in VinuChain's release path: mainnet already
+has Podgorica active, so an upgrade starts with the flag true and never changes
+it. A fresh activation has one monotonic false-to-true change in the serialized
+epoch seal before block dispatch and before any non-zero refund receipt can
+exist; all earlier refunds are nil or zero and encode identically. A second
+writer, reverse transition, or post-dispatch activation would require a code
+fix; the consumer's activation-order tests pin the current invariant.
 
 Two full-package p2p tests (`TestServerSetupConn` and `TestServerPeerLimits`)
 remain inherited timing/order flakes. CI runs the deterministic peer security

--- a/SECURITY-TRIAGE.md
+++ b/SECURITY-TRIAGE.md
@@ -17,8 +17,8 @@ devp2p and snap peer input is reachable.
 | CVE-2024-32972 | v1.13.15 | Not applicable: the vulnerable `GetHeadersFrom(num+count-1, count-1)` optimization does not exist; the inherited loop returns immediately for `Amount == 0`. The geth `eth` protocol is also not registered by VinuChain. |
 | CVE-2026-22862 | v1.16.8 | Applied: ECIES rejects ciphertext shorter than the public key, MAC, and AES block before slicing the IV; `TestDecryptRejectsShortCiphertext` covers it. |
 | CVE-2026-22868 | v1.16.8 | Not applicable: this fork has no blob transaction implementation or KZG verifier, rejects type `0x03` in both full and light transaction pools, and VinuChain does not use geth's transaction fetcher. |
-| CVE-2026-26313 | v1.17.0 | Applied to the reachable snap protocol: response lists remain raw until their encoded byte and item counts are bounded; `TestDecodeResponseListLimits` covers both limits. The unregistered geth `eth` handlers need no backport. |
-| CVE-2026-26314 | v1.16.9 | Applied in `e67de77a2`: `BitCurve.IsOnCurve` rejects nil, negative, and non-canonical coordinates; its regression test covers coordinates at and above the field prime. |
+| CVE-2026-26313 | v1.17.0 | Applied to the reachable snap protocol: response lists and nested trie-node request paths remain raw until their encoded byte and item counts are bounded; focused tests cover each limit. The unregistered geth `eth` handlers need no backport. |
+| CVE-2026-26314 | v1.16.9 | Applied on the supported Linux/CGO path: `BitCurve.IsOnCurve` rejects non-canonical coordinates and the C scalar multiplier checks field parsing; focused tests cover coordinates at the field prime. |
 | CVE-2026-26315 | v1.16.9 | Applied in `407a9c5ca`: ECIES validates peer coordinates before ECDH; off-curve and nil-coordinate regression tests cover it. |
 
 The effective fork version and the left-hand `github.com/ethereum/go-ethereum`
@@ -30,6 +30,10 @@ proved inapplicable in the fork.
 These patches affect unauthenticated network parsing only. They do not change
 the EVM, state transition, receipt encoding, chain rules, activation heights,
 or protocol capability names.
+
+Release binaries require Linux/CGO. The inherited non-CGO signature backend
+does not compile against the current btcec dependency and is not a supported
+VinuChain build target; no advisory disposition relies on it.
 
 The separate `FeeRefundActive` audit concern was checked in the consumer. The
 node initializes it from stored rules and changes it in the serialized epoch

--- a/core/types/fee_refund_epoch_test.go
+++ b/core/types/fee_refund_epoch_test.go
@@ -133,17 +133,14 @@ func TestReceiptRoot_StableForFixedFlag(t *testing.T) {
 // even be encoded under different flag values (EncodeIndex is called per-index),
 // producing a root that matches NEITHER the pre- nor the post-epoch root.
 //
-// This test PASSES today only because it asserts the hazard exists; it documents
-// the precise unsafe interleaving so that any future change which makes the flag
-// flip mid-derivation is caught. The SAFE operating contract is therefore:
-//
-//	FeeRefundActive MUST be set exactly once, before any block import/replay/RPC
-//	derivation begins, and MUST NOT be flipped while the process is live.
-//
-// If the consumer node instead flips the flag at the Podgorica block boundary
-// mid-process, historical receipt re-encodes (sync, re-org, replay, RPC
-// receipt-root checks) become non-deterministic. That is the unsafe design the
-// audit flags; this test is the executable evidence for it.
+// This test PASSES today only because it asserts the generic hazard exists. A
+// consumer must not change the flag while roots containing non-zero refunds can
+// be derived. VinuChain's sole live transition is the narrower safe case: a
+// monotonic false-to-true change in the serialized epoch seal, before dispatch
+// of the first block eligible to produce a non-zero refund. All earlier refunds
+// are nil or zero, so their encoding is identical in either state. A second
+// writer, a reverse transition, or moving activation after block dispatch would
+// violate that operating contract; this test preserves evidence of why.
 func TestReceiptRoot_ConcurrentFlagFlipObservesWrongEpoch(t *testing.T) {
 	saveAndRestoreFeeRefundActive(t)
 

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -58,6 +58,13 @@ func TestToECDSAErrors(t *testing.T) {
 	}
 }
 
+func TestS256RejectsCoordinatesAboveP(t *testing.T) {
+	curve := S256()
+	if curve.IsOnCurve(curve.Params().P, curve.Params().Gy) {
+		t.Fatal("S256 accepted coordinate at field prime")
+	}
+}
+
 func BenchmarkSha3(b *testing.B) {
 	a := []byte("hello world")
 	for i := 0; i < b.N; i++ {

--- a/crypto/ecies/ecies.go
+++ b/crypto/ecies/ecies.go
@@ -292,7 +292,7 @@ func (prv *PrivateKey) Decrypt(c, s1, s2 []byte) (m []byte, err error) {
 	switch c[0] {
 	case 2, 3, 4:
 		rLen = (prv.PublicKey.Curve.Params().BitSize + 7) / 4
-		if len(c) < (rLen + hLen + 1) {
+		if len(c) < (rLen + hLen + params.BlockSize) {
 			return nil, ErrInvalidMessage
 		}
 	default:

--- a/crypto/ecies/ecies_test.go
+++ b/crypto/ecies/ecies_test.go
@@ -234,6 +234,30 @@ func TestEncryptDecrypt(t *testing.T) {
 	}
 }
 
+func TestDecryptRejectsShortCiphertext(t *testing.T) {
+	prv, err := GenerateKey(rand.Reader, DefaultCurve, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	eph, err := GenerateKey(rand.Reader, DefaultCurve, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	params := ParamsFromCurve(DefaultCurve)
+	z, err := eph.GenerateShared(&prv.PublicKey, params.KeyLen, params.KeyLen)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, km := deriveKeys(params.Hash(), z, nil, params.KeyLen)
+	em := make([]byte, params.BlockSize-1)
+	pub := elliptic.Marshal(DefaultCurve, eph.PublicKey.X, eph.PublicKey.Y)
+	ciphertext := append(append(pub, em...), messageTag(params.Hash, km, em, nil)...)
+
+	if _, err := prv.Decrypt(ciphertext, nil, nil); err != ErrInvalidMessage {
+		t.Fatalf("Decrypt returned %v, want ErrInvalidMessage", err)
+	}
+}
+
 func TestDecryptShared2(t *testing.T) {
 	prv, err := GenerateKey(rand.Reader, DefaultCurve, nil)
 	if err != nil {
@@ -471,8 +495,8 @@ func TestGenerateShared_RejectsNilCoordinates(t *testing.T) {
 	}
 
 	for _, tc := range []struct {
-		name    string
-		x, y    *big.Int
+		name string
+		x, y *big.Int
 	}{
 		{"nil X", nil, big.NewInt(1)},
 		{"nil Y", big.NewInt(1), nil},

--- a/crypto/secp256k1/ext.h
+++ b/crypto/secp256k1/ext.h
@@ -109,8 +109,10 @@ int secp256k1_ext_scalar_mul(const secp256k1_context* ctx, unsigned char *point,
 	ARG_CHECK(scalar != NULL);
 	(void)ctx;
 
-	secp256k1_fe_set_b32(&feX, point);
-	secp256k1_fe_set_b32(&feY, point+32);
+	if (!secp256k1_fe_set_b32(&feX, point) ||
+		!secp256k1_fe_set_b32(&feY, point+32)) {
+		return 0;
+	}
 	secp256k1_ge_set_xy(&ge, &feX, &feY);
 	secp256k1_scalar_set_b32(&s, scalar, &overflow);
 	if (overflow || secp256k1_scalar_is_zero(&s)) {

--- a/crypto/secp256k1/scalar_mult_cgo.go
+++ b/crypto/secp256k1/scalar_mult_cgo.go
@@ -27,6 +27,9 @@ func (BitCurve *BitCurve) ScalarMult(Bx, By *big.Int, scalar []byte) (*big.Int, 
 	if len(scalar) > 32 {
 		panic("can't handle scalars > 256 bits")
 	}
+	if !BitCurve.IsOnCurve(Bx, By) {
+		return nil, nil
+	}
 	// NOTE: potential timing issue
 	padded := make([]byte, 32)
 	copy(padded[32-len(scalar):], scalar)

--- a/crypto/secp256k1/secp256_test.go
+++ b/crypto/secp256k1/secp256_test.go
@@ -279,10 +279,18 @@ func TestIsOnCurve_RejectsCoordinatesAboveP(t *testing.T) {
 	}
 }
 
-func TestScalarMultRejectsCoordinatesAboveP(t *testing.T) {
+func TestScalarMultRejectsNonCanonicalCoordinates(t *testing.T) {
 	curve := S256()
-	x, y := curve.ScalarMult(curve.Params().P, curve.Params().Gy, []byte{1})
-	if x != nil || y != nil {
-		t.Fatalf("ScalarMult accepted coordinate at field prime: (%v, %v)", x, y)
+	overflow := new(big.Int).Lsh(big.NewInt(1), 256)
+	overflow.Add(overflow, curve.Params().Gx)
+	for name, inputX := range map[string]*big.Int{
+		"field prime": curve.Params().P,
+		"truncated":   overflow,
+		"negative":    new(big.Int).Neg(curve.Params().Gx),
+	} {
+		x, y := curve.ScalarMult(inputX, curve.Params().Gy, []byte{1})
+		if x != nil || y != nil {
+			t.Fatalf("ScalarMult accepted %s coordinate: (%v, %v)", name, x, y)
+		}
 	}
 }

--- a/crypto/secp256k1/secp256_test.go
+++ b/crypto/secp256k1/secp256_test.go
@@ -278,3 +278,11 @@ func TestIsOnCurve_RejectsCoordinatesAboveP(t *testing.T) {
 		t.Error("IsOnCurve accepted (Gx, P): coordinate equal to P not rejected")
 	}
 }
+
+func TestScalarMultRejectsCoordinatesAboveP(t *testing.T) {
+	curve := S256()
+	x, y := curve.ScalarMult(curve.Params().P, curve.Params().Gy, []byte{1})
+	if x != nil || y != nil {
+		t.Fatalf("ScalarMult accepted coordinate at field prime: (%v, %v)", x, y)
+	}
+}

--- a/eth/protocols/snap/handler.go
+++ b/eth/protocols/snap/handler.go
@@ -56,6 +56,7 @@ const (
 	// at the remote side, which means all the work is in vain.
 	maxTrieNodeTimeSpent = 5 * time.Second
 
+	maxResponseBytes = softResponseLimit + softResponseLimit/10
 	maxResponseItems = softResponseLimit / common.HashLength
 	maxProofNodes    = 128
 )
@@ -68,8 +69,8 @@ func decodeResponseList(raw rlp.RawValue, maxItems int, out interface{}) error {
 	if len(rest) != 0 {
 		return fmt.Errorf("trailing data")
 	}
-	if len(content) > softResponseLimit {
-		return fmt.Errorf("encoded size %d exceeds %d", len(content), softResponseLimit)
+	if len(content) > maxResponseBytes {
+		return fmt.Errorf("encoded size %d exceeds %d", len(content), maxResponseBytes)
 	}
 	items, err := rlp.CountValues(content)
 	if err != nil {
@@ -79,6 +80,48 @@ func decodeResponseList(raw rlp.RawValue, maxItems int, out interface{}) error {
 		return fmt.Errorf("item count %d exceeds %d", items, maxItems)
 	}
 	return rlp.DecodeBytes(raw, out)
+}
+
+func decodeTrieNodePaths(raw rlp.RawValue) ([]TrieNodePathSet, error) {
+	content, rest, err := rlp.SplitList(raw)
+	if err != nil {
+		return nil, err
+	}
+	if len(rest) != 0 {
+		return nil, fmt.Errorf("trailing data")
+	}
+	var (
+		paths    []TrieNodePathSet
+		segments int
+	)
+	for len(content) > 0 {
+		if len(paths) >= maxTrieNodeLookups {
+			return nil, fmt.Errorf("path set count exceeds %d", maxTrieNodeLookups)
+		}
+		kind, inner, next, err := rlp.Split(content)
+		if err != nil {
+			return nil, err
+		}
+		if kind != rlp.List {
+			return nil, rlp.ErrExpectedList
+		}
+		var pathset TrieNodePathSet
+		for len(inner) > 0 {
+			segments++
+			if segments > maxTrieNodeLookups {
+				return nil, fmt.Errorf("path count exceeds %d", maxTrieNodeLookups)
+			}
+			path, rest, err := rlp.SplitString(inner)
+			if err != nil {
+				return nil, err
+			}
+			pathset = append(pathset, path)
+			inner = rest
+		}
+		paths = append(paths, pathset)
+		content = next
+	}
+	return paths, nil
 }
 
 // Handler is a callback to invoke from an outside runner after the boilerplate
@@ -483,10 +526,20 @@ func handleMessage(backend Backend, peer *Peer) error {
 
 	case msg.Code == GetTrieNodesMsg:
 		// Decode trie node retrieval request
-		var req GetTrieNodesPacket
-		if err := msg.Decode(&req); err != nil {
+		var raw struct {
+			ID    uint64
+			Root  common.Hash
+			Paths rlp.RawValue
+			Bytes uint64
+		}
+		if err := msg.Decode(&raw); err != nil {
 			return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
 		}
+		paths, err := decodeTrieNodePaths(raw.Paths)
+		if err != nil {
+			return fmt.Errorf("%w: trie node paths: %v", errDecode, err)
+		}
+		req := GetTrieNodesPacket{ID: raw.ID, Root: raw.Root, Paths: paths, Bytes: raw.Bytes}
 		if req.Bytes > softResponseLimit {
 			req.Bytes = softResponseLimit
 		}

--- a/eth/protocols/snap/handler.go
+++ b/eth/protocols/snap/handler.go
@@ -55,7 +55,31 @@ const (
 	// If we spend too much time, then it's a fairly high chance of timing out
 	// at the remote side, which means all the work is in vain.
 	maxTrieNodeTimeSpent = 5 * time.Second
+
+	maxResponseItems = softResponseLimit / common.HashLength
+	maxProofNodes    = 128
 )
+
+func decodeResponseList(raw rlp.RawValue, maxItems int, out interface{}) error {
+	content, rest, err := rlp.SplitList(raw)
+	if err != nil {
+		return err
+	}
+	if len(rest) != 0 {
+		return fmt.Errorf("trailing data")
+	}
+	if len(content) > softResponseLimit {
+		return fmt.Errorf("encoded size %d exceeds %d", len(content), softResponseLimit)
+	}
+	items, err := rlp.CountValues(content)
+	if err != nil {
+		return err
+	}
+	if items > maxItems {
+		return fmt.Errorf("item count %d exceeds %d", items, maxItems)
+	}
+	return rlp.DecodeBytes(raw, out)
+}
 
 // Handler is a callback to invoke from an outside runner after the boilerplate
 // exchanges have passed.
@@ -233,9 +257,20 @@ func handleMessage(backend Backend, peer *Peer) error {
 
 	case msg.Code == AccountRangeMsg:
 		// A range of accounts arrived to one of our previous requests
-		res := new(AccountRangePacket)
-		if err := msg.Decode(res); err != nil {
+		var raw struct {
+			ID       uint64
+			Accounts rlp.RawValue
+			Proof    rlp.RawValue
+		}
+		if err := msg.Decode(&raw); err != nil {
 			return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+		}
+		res := &AccountRangePacket{ID: raw.ID}
+		if err := decodeResponseList(raw.Accounts, maxResponseItems, &res.Accounts); err != nil {
+			return fmt.Errorf("%w: account range: %v", errDecode, err)
+		}
+		if err := decodeResponseList(raw.Proof, maxProofNodes, &res.Proof); err != nil {
+			return fmt.Errorf("%w: account proof: %v", errDecode, err)
 		}
 		// Ensure the range is monotonically increasing
 		for i := 1; i < len(res.Accounts); i++ {
@@ -366,9 +401,20 @@ func handleMessage(backend Backend, peer *Peer) error {
 
 	case msg.Code == StorageRangesMsg:
 		// A range of storage slots arrived to one of our previous requests
-		res := new(StorageRangesPacket)
-		if err := msg.Decode(res); err != nil {
+		var raw struct {
+			ID    uint64
+			Slots rlp.RawValue
+			Proof rlp.RawValue
+		}
+		if err := msg.Decode(&raw); err != nil {
 			return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+		}
+		res := &StorageRangesPacket{ID: raw.ID}
+		if err := decodeResponseList(raw.Slots, maxResponseItems, &res.Slots); err != nil {
+			return fmt.Errorf("%w: storage ranges: %v", errDecode, err)
+		}
+		if err := decodeResponseList(raw.Proof, maxProofNodes, &res.Proof); err != nil {
+			return fmt.Errorf("%w: storage proof: %v", errDecode, err)
 		}
 		// Ensure the ranges are monotonically increasing
 		for i, slots := range res.Slots {
@@ -420,9 +466,16 @@ func handleMessage(backend Backend, peer *Peer) error {
 
 	case msg.Code == ByteCodesMsg:
 		// A batch of byte codes arrived to one of our previous requests
-		res := new(ByteCodesPacket)
-		if err := msg.Decode(res); err != nil {
+		var raw struct {
+			ID    uint64
+			Codes rlp.RawValue
+		}
+		if err := msg.Decode(&raw); err != nil {
 			return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+		}
+		res := &ByteCodesPacket{ID: raw.ID}
+		if err := decodeResponseList(raw.Codes, maxCodeLookups, &res.Codes); err != nil {
+			return fmt.Errorf("%w: byte codes: %v", errDecode, err)
 		}
 		requestTracker.Fulfil(peer.id, peer.version, ByteCodesMsg, res.ID)
 
@@ -515,9 +568,16 @@ func handleMessage(backend Backend, peer *Peer) error {
 
 	case msg.Code == TrieNodesMsg:
 		// A batch of trie nodes arrived to one of our previous requests
-		res := new(TrieNodesPacket)
-		if err := msg.Decode(res); err != nil {
+		var raw struct {
+			ID    uint64
+			Nodes rlp.RawValue
+		}
+		if err := msg.Decode(&raw); err != nil {
 			return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+		}
+		res := &TrieNodesPacket{ID: raw.ID}
+		if err := decodeResponseList(raw.Nodes, maxTrieNodeLookups, &res.Nodes); err != nil {
+			return fmt.Errorf("%w: trie nodes: %v", errDecode, err)
 		}
 		requestTracker.Fulfil(peer.id, peer.version, TrieNodesMsg, res.ID)
 

--- a/eth/protocols/snap/handler.go
+++ b/eth/protocols/snap/handler.go
@@ -59,6 +59,7 @@ const (
 	maxResponseBytes = softResponseLimit + softResponseLimit/10
 	maxResponseItems = softResponseLimit / common.HashLength
 	maxPathSegments  = 2 * maxTrieNodeLookups
+	maxPathSize      = common.HashLength + 1
 	maxProofNodes    = 128
 )
 
@@ -115,6 +116,9 @@ func decodeTrieNodePaths(raw rlp.RawValue) ([]TrieNodePathSet, error) {
 			path, rest, err := rlp.SplitString(inner)
 			if err != nil {
 				return nil, err
+			}
+			if len(path) > maxPathSize {
+				return nil, fmt.Errorf("path length %d exceeds %d", len(path), maxPathSize)
 			}
 			pathset = append(pathset, path)
 			inner = rest

--- a/eth/protocols/snap/handler.go
+++ b/eth/protocols/snap/handler.go
@@ -58,6 +58,7 @@ const (
 
 	maxResponseBytes = softResponseLimit + softResponseLimit/10
 	maxResponseItems = softResponseLimit / common.HashLength
+	maxPathSegments  = 2 * maxTrieNodeLookups
 	maxProofNodes    = 128
 )
 
@@ -108,8 +109,8 @@ func decodeTrieNodePaths(raw rlp.RawValue) ([]TrieNodePathSet, error) {
 		var pathset TrieNodePathSet
 		for len(inner) > 0 {
 			segments++
-			if segments > maxTrieNodeLookups {
-				return nil, fmt.Errorf("path count exceeds %d", maxTrieNodeLookups)
+			if segments > maxPathSegments {
+				return nil, fmt.Errorf("path count exceeds %d", maxPathSegments)
 			}
 			path, rest, err := rlp.SplitString(inner)
 			if err != nil {

--- a/eth/protocols/snap/handler_security_test.go
+++ b/eth/protocols/snap/handler_security_test.go
@@ -81,7 +81,19 @@ func TestDecodeTrieNodePathsLimits(t *testing.T) {
 		t.Fatalf("decodeTrieNodePaths returned %v, want path-set error", err)
 	}
 
-	tooManyPaths, err := rlp.EncodeToBytes([]TrieNodePathSet{make(TrieNodePathSet, maxTrieNodeLookups+1)})
+	validMax := make([]TrieNodePathSet, maxTrieNodeLookups)
+	for i := range validMax {
+		validMax[i] = TrieNodePathSet{nil, nil}
+	}
+	raw, err = rlp.EncodeToBytes(validMax)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := decodeTrieNodePaths(raw); err != nil {
+		t.Fatalf("decodeTrieNodePaths rejected valid maximum: %v", err)
+	}
+
+	tooManyPaths, err := rlp.EncodeToBytes([]TrieNodePathSet{make(TrieNodePathSet, maxPathSegments+1)})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/eth/protocols/snap/handler_security_test.go
+++ b/eth/protocols/snap/handler_security_test.go
@@ -100,4 +100,20 @@ func TestDecodeTrieNodePathsLimits(t *testing.T) {
 	if _, err := decodeTrieNodePaths(tooManyPaths); err == nil || !strings.Contains(err.Error(), "path count") {
 		t.Fatalf("decodeTrieNodePaths returned %v, want path-count error", err)
 	}
+
+	validPath, err := rlp.EncodeToBytes([]TrieNodePathSet{{make([]byte, maxPathSize)}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := decodeTrieNodePaths(validPath); err != nil {
+		t.Fatalf("decodeTrieNodePaths rejected maximum path length: %v", err)
+	}
+
+	tooLong, err := rlp.EncodeToBytes([]TrieNodePathSet{{make([]byte, maxPathSize+1)}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := decodeTrieNodePaths(tooLong); err == nil || !strings.Contains(err.Error(), "path length") {
+		t.Fatalf("decodeTrieNodePaths returned %v, want path-length error", err)
+	}
 }

--- a/eth/protocols/snap/handler_security_test.go
+++ b/eth/protocols/snap/handler_security_test.go
@@ -1,0 +1,52 @@
+// Copyright 2026 The go-vinu Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+
+package snap
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+func TestDecodeResponseListLimits(t *testing.T) {
+	want := [][]byte{{1}, {2}}
+	raw, err := rlp.EncodeToBytes(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got [][]byte
+	if err := decodeResponseList(raw, len(want), &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("decoded %d items, want %d", len(got), len(want))
+	}
+
+	tooMany, err := rlp.EncodeToBytes(make([][]byte, maxCodeLookups+1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := decodeResponseList(tooMany, maxCodeLookups, &got); err == nil || !strings.Contains(err.Error(), "item count") {
+		t.Fatalf("decodeResponseList returned %v, want item-count error", err)
+	}
+
+	tooLarge, err := rlp.EncodeToBytes([][]byte{make([]byte, softResponseLimit+1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := decodeResponseList(tooLarge, 1, &got); err == nil || !strings.Contains(err.Error(), "encoded size") {
+		t.Fatalf("decodeResponseList returned %v, want encoded-size error", err)
+	}
+}

--- a/eth/protocols/snap/handler_security_test.go
+++ b/eth/protocols/snap/handler_security_test.go
@@ -42,11 +42,50 @@ func TestDecodeResponseListLimits(t *testing.T) {
 		t.Fatalf("decodeResponseList returned %v, want item-count error", err)
 	}
 
-	tooLarge, err := rlp.EncodeToBytes([][]byte{make([]byte, softResponseLimit+1)})
+	compatible, err := rlp.EncodeToBytes([][]byte{make([]byte, softResponseLimit)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := decodeResponseList(compatible, 1, &got); err != nil {
+		t.Fatalf("decodeResponseList rejected protocol slack: %v", err)
+	}
+
+	tooLarge, err := rlp.EncodeToBytes([][]byte{make([]byte, maxResponseBytes+1)})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if err := decodeResponseList(tooLarge, 1, &got); err == nil || !strings.Contains(err.Error(), "encoded size") {
 		t.Fatalf("decodeResponseList returned %v, want encoded-size error", err)
+	}
+}
+
+func TestDecodeTrieNodePathsLimits(t *testing.T) {
+	want := []TrieNodePathSet{{{1}, {2}}, {{3}}}
+	raw, err := rlp.EncodeToBytes(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := decodeTrieNodePaths(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || len(got[0]) != 2 || len(got[1]) != 1 {
+		t.Fatalf("decoded path shape %v, want [2 1]", got)
+	}
+
+	tooManySets, err := rlp.EncodeToBytes(make([]TrieNodePathSet, maxTrieNodeLookups+1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := decodeTrieNodePaths(tooManySets); err == nil || !strings.Contains(err.Error(), "path set count") {
+		t.Fatalf("decodeTrieNodePaths returned %v, want path-set error", err)
+	}
+
+	tooManyPaths, err := rlp.EncodeToBytes([]TrieNodePathSet{make(TrieNodePathSet, maxTrieNodeLookups+1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := decodeTrieNodePaths(tooManyPaths); err == nil || !strings.Contains(err.Error(), "path count") {
+		t.Fatalf("decodeTrieNodePaths returned %v, want path-count error", err)
 	}
 }

--- a/eth/protocols/snap/sync_test.go
+++ b/eth/protocols/snap/sync_test.go
@@ -1658,7 +1658,7 @@ func TestSyncAccountPerformance(t *testing.T) {
 	// Doing so would bring this number down to zero in this artificial testcase,
 	// but only add extra IO for no reason in practice.
 	if have, want := src.nTrienodeRequests, 1; have != want {
-		fmt.Printf(src.Stats())
+		fmt.Print(src.Stats())
 		t.Errorf("trie node heal requests wrong, want %d, have %d", want, have)
 	}
 }

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -337,11 +337,11 @@ func (p *Peer) handle(msg Msg) error {
 		case <-p.closed:
 		}
 	case msg.Code == discMsg:
-		var reason [1]DiscReason
 		// This is the last message. We don't need to discard or
 		// check errors because, the connection will be closed after it.
-		rlp.Decode(msg.Payload, &reason)
-		return reason[0]
+		var m struct{ Reason DiscReason }
+		rlp.Decode(msg.Payload, &m)
+		return m.Reason
 	case msg.Code < baseProtocolLength:
 		// ignore other base protocol messages
 		return msg.Discard()

--- a/p2p/peer_error.go
+++ b/p2p/peer_error.go
@@ -54,7 +54,7 @@ func (pe *peerError) Error() string {
 
 var errProtocolReturned = errors.New("protocol returned")
 
-type DiscReason uint
+type DiscReason uint8
 
 const (
 	DiscRequested DiscReason = iota

--- a/params/version.go
+++ b/params/version.go
@@ -29,7 +29,7 @@ var (
 	// tracks the VinuChain release tag. It is a display string only — it is not
 	// parsed for any consensus or protocol decision. Keep in sync with the
 	// release tag (see README "Versioning").
-	VersionMeta = "vinu-v1.20.25-quota"
+	VersionMeta = "vinu-v1.20.26-quota"
 )
 
 // Version holds the textual version string.


### PR DESCRIPTION
Closes the remaining geth dependency-security gap before the Elemont mainnet rollout.

- rejects undersized ECIES ciphertexts before AES slicing (CVE-2026-22862)
- bounds fsnap response lists while still raw (CVE-2026-26313)
- applies the one-byte disconnect reason fix (CVE-2022-29177)
- records code-backed dispositions for the other current geth advisories
- adds focused CI and race-tested regressions

VinuChain does not register geth eth protocols and rejects unsupported blob transactions. These changes affect unauthenticated peer parsing only; EVM, state transition, receipts, chain rules, activation heights, and protocol names are unchanged.